### PR TITLE
Avoid logging info messages to stderr, fixes #8

### DIFF
--- a/plugin/vimwatcher.py
+++ b/plugin/vimwatcher.py
@@ -35,6 +35,10 @@ def main(testing=False):
         client_logger.setLevel(logging.WARNING)
     setup_logging(name, testing=testing, log_stderr=True, log_file=testing)
 
+    # change back log level changed in setup_logging(), see issue #8
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO if testing else logging.WARNING)
+
     config = load_config()
     pulsetime = config[name].getfloat("pulsetime")
 


### PR DESCRIPTION
This sets the log level of the root logger to WARNING to prevent the
display of irrelevant messages after every VIM startup.

Solves #8 