### PR TITLE
Add configuration for Api Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ Once installed in the bundle directory, it should load automatically if you have
 ```
 
 If aw-watcher-vim loses connection it will give you an error message and stop logging. You then need to either run :AWStart or restart vim to start logging again
+
+### Configuration
+
+The following global variables are available:
+
+| Variable Name      | Description                    | Default Value |
+|--------------------|--------------------------------|---------------|
+| `g:aw_apiurl_host` | Sets the _host_ of the Api Url | `127.0.0.1`   |
+| `g:aw_apiurl_port` | Sets the _port_ of the Api Url | `5600`        |

--- a/plugin/activitywatch.vim
+++ b/plugin/activitywatch.vim
@@ -15,7 +15,9 @@ let s:language = ''
 let s:project = ''
 
 let s:connected = 0
-let s:base_apiurl = 'http://127.0.0.1:5600/api/0'
+let s:apiurl_host = get(g:, 'aw_apiurl_host', '127.0.0.1')
+let s:apiurl_port = get(g:, 'aw_apiurl_port', '5600')
+let s:base_apiurl = printf('http://%s:%s/api/0', s:apiurl_host, s:apiurl_port)
 let s:hostname = hostname()
 let s:bucketname = printf('aw-watcher-vim_%s', s:hostname)
 let s:bucket_apiurl = printf('%s/buckets/%s', s:base_apiurl, s:bucketname)


### PR DESCRIPTION
I started using Activity Watch recently on my work machine.
Because of my weird setup, I need to change the host for it to work properly, so instead of just copying this script, I decided to make it configurable.

The change is pretty simple, but I'm not sure if I use the right terms.