### PR TITLE
fix: use detach process to run curl and set timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ If aw-watcher-vim loses connection it will give you an error message and stop lo
 
 The following global variables are available:
 
-| Variable Name      | Description                    | Default Value |
-|--------------------|--------------------------------|---------------|
-| `g:aw_apiurl_host` | Sets the _host_ of the Api Url | `127.0.0.1`   |
-| `g:aw_apiurl_port` | Sets the _port_ of the Api Url | `5600`        |
+| Variable Name      | Description                                    | Default Value |
+|--------------------|------------------------------------------------|---------------|
+| `g:aw_apiurl_host` | Sets the _host_ of the Api Url                 | `127.0.0.1`   |
+| `g:aw_apiurl_port` | Sets the _port_ of the Api Url                 | `5600`        |
+| `g:aw_api_timeout` | Sets the _timeout_ seconds of the Api request  | `2.0`         |

--- a/plugin/activitywatch.vim
+++ b/plugin/activitywatch.vim
@@ -17,6 +17,7 @@ let s:project = ''
 let s:connected = 0
 let s:apiurl_host = get(g:, 'aw_apiurl_host', '127.0.0.1')
 let s:apiurl_port = get(g:, 'aw_apiurl_port', '5600')
+let s:api_timeout = get(g:, 'aw_api_timeout', 2)
 let s:base_apiurl = printf('http://%s:%s/api/0', s:apiurl_host, s:apiurl_port)
 let s:hostname = hostname()
 let s:bucketname = printf('aw-watcher-vim_%s', s:hostname)
@@ -33,10 +34,12 @@ function! HTTPPostJson(url, data)
         \ '-X', 'POST',
         \ '-d', json_encode(a:data),
         \ '-o', '/dev/null',
+        \ '-m', s:api_timeout,
         \ '-w', "%{http_code}"]
     if s:nvim
         let l:req_job = jobstart(l:req,
-            \ {"on_stdout": "HTTPPostOnStdoutNeovim",
+            \ {"detach": 1,
+            \  "on_stdout": "HTTPPostOnStdoutNeovim",
             \  "on_exit": "HTTPPostOnExitNeovim",
         \ })
     else


### PR DESCRIPTION
Fixes #17. 

`aw-watcher-vim` use `jobstart` to spawn a new process to run `curl` command. If the sub-process is still running, when we exit Nvim, the Nvim will send TERM signal to this process and execute `on_exit` handler.  we could not make sure that `on_stdout` handler is executed. So that is why the error `key not present in Dictionary`  occurs occasionally.

https://github.com/ActivityWatch/aw-watcher-vim/blob/8d9dc622a4f63d4251d39eced69300ce3de22309/plugin/activitywatch.vim#L87-L93

https://github.com/ActivityWatch/aw-watcher-vim/blob/8d9dc622a4f63d4251d39eced69300ce3de22309/plugin/activitywatch.vim#L51-L55


This PR uses detach mode to  run the job process. It will not be killed when Nvim exits. If the process exits before Nvim, `on_exit` will be invoked too. And to avoid `curl` hangs for a long time, I add the `--max-time/-m` option. The default value is `2.0` seconds.