### PR TITLE
fix: use full path to file and project

### DIFF
--- a/plugin/activitywatch.vim
+++ b/plugin/activitywatch.vim
@@ -113,9 +113,9 @@ function! s:Heartbeat()
     let l:duration = 0
     let l:localtime = localtime()
     let l:timestamp = strftime('%FT%H:%M:%S%z')
-    let l:file = expand('%p')
+    let l:file = expand('%:p')
     let l:language = &filetype
-    let l:project = getcwd()
+    let l:project = expand('%:p:h')
     " Only send heartbeat if data was changed or more than 1 second has passed
     " since last heartbeat
     if    s:file != l:file ||


### PR DESCRIPTION
This merge request makes the watcher send the full path of the edited file and project. Previously it was only sending relative paths, which is contrary to the [recommended activitywatch data standard](https://docs.activitywatch.net/en/latest/buckets-and-events.html#app-editor-activity).

This makes it easier to precisely sort work time into categories. In my case, this lets me differentiate between "Study" and "Work" which only differ based on some parent directories deep in their path.

I should add that this might still stray from the recommended data standard on Windows, which uses backward slashes rather than forward slashes. I'm not sure what's the best way to deal with this, though.