### PR TITLE
fix: revert not using cwd() for projects

### DIFF
--- a/plugin/activitywatch.vim
+++ b/plugin/activitywatch.vim
@@ -115,7 +115,7 @@ function! s:Heartbeat()
     let l:timestamp = strftime('%FT%H:%M:%S%z')
     let l:file = expand('%:p')
     let l:language = &filetype
-    let l:project = expand('%:p:h')
+    let l:project = getcwd()
     " Only send heartbeat if data was changed or more than 1 second has passed
     " since last heartbeat
     if    s:file != l:file ||


### PR DESCRIPTION
Thanks for the plugin!

This PR rolls back the change for projects added in https://github.com/3rd/aw-watcher-vim/commit/d595afc6f35a6567553ca999ece544982385fa35 as for most users the project root is the current working directory.